### PR TITLE
Use cargoHash instead of cargoSha256

### DIFF
--- a/xwayland-satellite.nix
+++ b/xwayland-satellite.nix
@@ -26,7 +26,7 @@ rustPlatform.buildRustPackage {
     makeWrapper
   ];
 
-  cargoSha256 = "sha256-XizbD9AsRz0DiGyt08E00Ae27/2NV35PdhoV2blQBJg=";
+  cargoHash = "sha256-XizbD9AsRz0DiGyt08E00Ae27/2NV35PdhoV2blQBJg=";
 
   postInstall = ''
     wrapProgram $out/bin/xwayland-satellite \


### PR DESCRIPTION
With the newest nixpkgs cargoHash, cargoVendorDir, cargoDeps or cargoLock must be set. cargoSha256 has been deprecated for a while.